### PR TITLE
libbinder: allow devices to disable ashmem size tracking

### DIFF
--- a/include/binder/Parcel.h
+++ b/include/binder/Parcel.h
@@ -340,8 +340,10 @@ public:
         inline void* data() { return mData; }
     };
 
+#ifndef DISABLE_ASHMEM_TRACKING
 private:
     size_t mOpenAshmemSize;
+#endif
 
 public:
     // TODO: Remove once ABI can be changed.

--- a/libs/binder/Parcel.cpp
+++ b/libs/binder/Parcel.cpp
@@ -182,6 +182,10 @@ static void release_object(const sp<ProcessState>& proc,
 
                     close(obj.handle);
                 }
+#ifdef DISABLE_ASHMEM_TRACKING
+            } else if (obj.cookie != 0) {
+                close(obj.handle);
+#endif
             }
             return;
         }
@@ -532,7 +536,11 @@ status_t Parcel::appendFrom(const Parcel *parcel, size_t offset, size_t len)
 
             flat_binder_object* flat
                 = reinterpret_cast<flat_binder_object*>(mData + off);
+#ifndef DISABLE_ASHMEM_TRACKING
             acquire_object(proc, *flat, this, &mOpenAshmemSize);
+#else
+            acquire_object(proc, *flat, this);
+#endif
 
             if (flat->type == BINDER_TYPE_FD) {
                 // If this is a file descriptor, we need to dup it so the
@@ -1052,7 +1060,11 @@ restart_write:
         // Need to write meta-data?
         if (nullMetaData || val.binder != 0) {
             mObjects[mObjectsSize] = mDataPos;
+#ifndef DISABLE_ASHMEM_TRACKING
             acquire_object(ProcessState::self(), val, this, &mOpenAshmemSize);
+#else
+            acquire_object(ProcessState::self(), val, this);
+#endif
             mObjectsSize++;
         }
 
@@ -1635,7 +1647,11 @@ void Parcel::releaseObjects()
         i--;
         const flat_binder_object* flat
             = reinterpret_cast<flat_binder_object*>(data+objects[i]);
+#ifndef DISABLE_ASHMEM_TRACKING
         release_object(proc, *flat, this, &mOpenAshmemSize);
+#else
+        release_object(proc, *flat, this);
+#endif
     }
 }
 
@@ -1649,7 +1665,11 @@ void Parcel::acquireObjects()
         i--;
         const flat_binder_object* flat
             = reinterpret_cast<flat_binder_object*>(data+objects[i]);
+#ifndef DISABLE_ASHMEM_TRACKING
         acquire_object(proc, *flat, this, &mOpenAshmemSize);
+#else
+        acquire_object(proc, *flat, this);
+#endif
     }
 }
 
@@ -1831,7 +1851,11 @@ status_t Parcel::continueWrite(size_t desired)
                     // will need to rescan because we may have lopped off the only FDs
                     mFdsKnown = false;
                 }
+#ifndef DISABLE_ASHMEM_TRACKING
                 release_object(proc, *flat, this, &mOpenAshmemSize);
+#else
+                release_object(proc, *flat, this);
+#endif
             }
             binder_size_t* objects =
                 (binder_size_t*)realloc(mObjects, objectsSize*sizeof(binder_size_t));
@@ -1916,7 +1940,9 @@ void Parcel::initState()
     mFdsKnown = true;
     mAllowFds = true;
     mOwner = NULL;
+#ifndef DISABLE_ASHMEM_TRACKING
     mOpenAshmemSize = 0;
+#endif
 }
 
 void Parcel::scanForFds() const
@@ -1939,12 +1965,20 @@ size_t Parcel::getBlobAshmemSize() const
     // This used to return the size of all blobs that were written to ashmem, now we're returning
     // the ashmem currently referenced by this Parcel, which should be equivalent.
     // TODO: Remove method once ABI can be changed.
+#ifndef DISABLE_ASHMEM_TRACKING
     return mOpenAshmemSize;
+#else
+    return 0;
+#endif
 }
 
 size_t Parcel::getOpenAshmemSize() const
 {
+#ifndef DISABLE_ASHMEM_TRACKING
     return mOpenAshmemSize;
+#else
+    return 0;
+#endif
 }
 
 // --- Parcel::Blob ---


### PR DESCRIPTION
The addition of ashmem size tracking can lead to parcel objects
overwriting other values on the stack in old binary blobs.

Change-Id: Ife8514be1ba639c4061de38b59794c46bcc2d7f8